### PR TITLE
feat: improve upsert data

### DIFF
--- a/src/CrudClient.ts
+++ b/src/CrudClient.ts
@@ -19,7 +19,7 @@ import got, { type RequestError, type Got } from 'got'
 import httpErrors from 'http-errors'
 import isEmpty from 'lodash.isempty'
 
-import type { ClientRequestContext, Filter, CrudUID, PatchBody, PatchBulkBody, ICrudClient } from './types'
+import type { ClientRequestContext, Filter, CrudUID, PatchBody, PatchBulkBody, ICrudClient, UpsertBody } from './types'
 import { queryFromFilter, getHttpErrors } from './utils'
 
 export class CrudClient<T> implements ICrudClient<T> {
@@ -191,7 +191,7 @@ export class CrudClient<T> implements ICrudClient<T> {
     }
   }
 
-  async upsertOne(ctx: ClientRequestContext, body: Record<string, unknown>, filter?: Filter): Promise<T> {
+  async upsertOne(ctx: ClientRequestContext, body: UpsertBody<T>, filter?: Filter): Promise<T> {
     const { logger, headersToProxy } = ctx
     try {
       const { body: item } = await this.client.post<T & CrudUID>('upsert-one', {

--- a/src/CrudClient.ts
+++ b/src/CrudClient.ts
@@ -35,7 +35,7 @@ export class CrudClient<T> implements ICrudClient<T> {
     this.resource = resource
   }
 
-  async getList(ctx: ClientRequestContext, filter?: Filter): Promise<T[]> {
+  async getList(ctx: ClientRequestContext, filter?: Filter<T>): Promise<T[]> {
     const { logger, headersToProxy } = ctx
     try {
       const { body: itemList } = await this.client.get<T[]>('', {
@@ -66,7 +66,7 @@ export class CrudClient<T> implements ICrudClient<T> {
    * @param {object} filter The filter to apply
    * @returns {array} The array of data
    */
-  async getExport(ctx: ClientRequestContext, filter?: Filter): Promise<T[]> {
+  async getExport(ctx: ClientRequestContext, filter?: Filter<T>): Promise<T[]> {
     const { logger, headersToProxy } = ctx
     try {
       const stream = this.client.stream('export', {
@@ -118,7 +118,7 @@ export class CrudClient<T> implements ICrudClient<T> {
     }
   }
 
-  async count(ctx: ClientRequestContext, filter?: Omit<Filter, 'projection'>): Promise<number> {
+  async count(ctx: ClientRequestContext, filter?: Omit<Filter<T>, 'projection'>): Promise<number> {
     const { logger, headersToProxy } = ctx
     try {
       const { body: count } = await this.client.get<number>('count', {
@@ -138,7 +138,7 @@ export class CrudClient<T> implements ICrudClient<T> {
     }
   }
 
-  async getById(ctx: ClientRequestContext, id: string, filter?: Pick<Filter, 'projection'>): Promise<T> {
+  async getById(ctx: ClientRequestContext, id: string, filter?: Pick<Filter<T>, 'projection'>): Promise<T> {
     const { logger, headersToProxy } = ctx
     try {
       const { body: item } = await this.client.get<T>(id, {
@@ -191,7 +191,7 @@ export class CrudClient<T> implements ICrudClient<T> {
     }
   }
 
-  async upsertOne(ctx: ClientRequestContext, body: UpsertBody<T>, filter?: Filter): Promise<T> {
+  async upsertOne(ctx: ClientRequestContext, body: UpsertBody<T>, filter?: Filter<T>): Promise<T> {
     const { logger, headersToProxy } = ctx
     try {
       const { body: item } = await this.client.post<T & CrudUID>('upsert-one', {
@@ -208,7 +208,7 @@ export class CrudClient<T> implements ICrudClient<T> {
     }
   }
 
-  async updateById(ctx: ClientRequestContext, id: string, body: PatchBody<T>, filter?: Filter): Promise<T> {
+  async updateById(ctx: ClientRequestContext, id: string, body: PatchBody<T>, filter?: Filter<T>): Promise<T> {
     const { logger, headersToProxy } = ctx
     try {
       const { body: item } = await this.client.patch<T>(id, {
@@ -225,7 +225,7 @@ export class CrudClient<T> implements ICrudClient<T> {
     }
   }
 
-  async updateMany(ctx: ClientRequestContext, body: PatchBody<T>, filter?: Filter): Promise<number> {
+  async updateMany(ctx: ClientRequestContext, body: PatchBody<T>, filter?: Filter<T>): Promise<number> {
     const { logger, headersToProxy } = ctx
     try {
       const { body: item } = await this.client.patch<number>('', {
@@ -285,7 +285,7 @@ export class CrudClient<T> implements ICrudClient<T> {
     }
   }
 
-  async delete(ctx: ClientRequestContext, filter: Filter): Promise<number> {
+  async delete(ctx: ClientRequestContext, filter: Filter<T>): Promise<number> {
     if (isEmpty(filter.mongoQuery)) {
       throw new httpErrors.BadRequest('Mongo query is required')
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export type ClientRequestContext = {
   localRequestId: string
 }
 
-export type Filter = {
+export type Filter<T = Record<string, unknown>> = Omit<Partial<Record<KeysMatching<T, string>, string>>, 'mongoQuery' | 'limit' | 'skip' | 'projection' | 'rawProjection' | 'sort'> & {
   mongoQuery?: Record<string, unknown>
   limit?: number
   skip?: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,3 +71,7 @@ export type CrudItem<T> = T & {
   updatedAt: string
   updaterId: string
 }
+
+export type UpsertBody<T> = PatchBody<T> & {
+  $setOnInsert?: Partial<T> & Record<string, unknown>
+}

--- a/tests/CrudClient.test.ts
+++ b/tests/CrudClient.test.ts
@@ -240,6 +240,37 @@ describe('CrudClient', () => {
       assert.deepStrictEqual(response, expectedResponse)
     })
 
+    it('returns the entities that match a filter with document filter', async() => {
+      const filter: Filter<Item> = {
+        id: 'my-id',
+        limit: 5,
+        skip: 1,
+        projection: ['id'],
+      }
+
+      const expectedResponse = [
+        {
+          id: 'my-id',
+          property: 'my-property',
+        },
+      ]
+      const crudScope = nock(CRUD_BASE_PATH)
+        .get('/')
+        .query({
+          id: 'my-id',
+          _l: '5',
+          _sk: '1',
+          _p: 'id',
+        })
+        .reply(200, expectedResponse)
+
+      const response = await client.getList(requestCtx, filter)
+      crudScope.done()
+
+      assert.deepStrictEqual(response, expectedResponse)
+    })
+
+
     it('throws 400', async() => {
       const filter = {
         mongoQuery: { fields: 'value' },


### PR DESCRIPTION
In crud-service, it is possible to filter by string fields at first level. In this PR, I add the support on this kind of filters.
Furthermore, it's enhanced the upsert body types to be a PatchBody, with the addition of `$setOnInsert` operator.